### PR TITLE
fix: sync canvas.Width in ResizeX to avoid stale-width render panic

### DIFF
--- a/canvas.go
+++ b/canvas.go
@@ -306,6 +306,9 @@ func (canvas *Canvas) ResizeY(h int) {
 }
 
 func (canvas *Canvas) ResizeX(w int) {
+	// Track the new width; row (re)inits seed their region size from it.
+	canvas.Width = w
+
 	// Handle width adjustment
 	for y := 0; y < len(canvas.Rows); y++ {
 		row := canvas.Rows[y]

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -263,6 +263,34 @@ func TestResizeGrowingHeightDoesNotBloatCanvas(t *testing.T) {
 	}
 }
 
+// TestResizeNarrowThenRedrawDoesNotPanic guards Canvas.ResizeX against
+// leaving canvas.Width stale after a width shrink. canvas.Width is the
+// seed size for every later row (re)init — Paint/Insert bootstrap,
+// ResizeY grow, and ClearRow (ESC[2J). If it stays at the old, wider
+// value, the next row re-init builds a format region wider than the
+// now-narrower content row, and renderLine's line[pos:pos+region.Size]
+// slice overruns it (panic: slice bounds out of range).
+func TestResizeNarrowThenRedrawDoesNotPanic(t *testing.T) {
+	// Wide initial grid: canvas.Width is seeded at 201.
+	vt := midterm.NewTerminal(24, 201)
+
+	// Shrink to a narrower width, as a window resize would.
+	vt.Resize(24, 95)
+
+	// Full-screen redraw after the resize: clear screen (ESC[2J re-inits
+	// each row at canvas.Width), home, then paint.
+	mustFprintf(t, vt, "\x1b[2J\x1b[Hhello")
+
+	buf := new(bytes.Buffer)
+	require.NoError(t, vt.Render(buf))
+
+	// Growing taller after the shrink also appends rows at canvas.Width;
+	// clear and repaint, then re-render the whole (now taller) grid.
+	vt.Resize(40, 95)
+	mustFprintf(t, vt, "\x1b[2J\x1b[40;1Hbottom")
+	require.NoError(t, vt.Render(buf))
+}
+
 func TestInsertModePreservesShiftedContentAcrossLines(t *testing.T) {
 	term := midterm.NewTerminal(24, 80)
 	term.Raw = true


### PR DESCRIPTION
First of all,  thanks for this project :pray: 

I noticed that `Canvas.ResizeX` truncates the existing rows to the new width but never updates `canvas.Width` itself, so the field stays frozen at its initial value.
 
That matters since `canvas.Width` is the seed size for every row that gets (re)initialized later (e.g. Paint/Insert bootstrap, ResizeY grow, and ClearRow (ESC[2J)). 
After a width shrink, the next such (re)init builds a format region wider than the now-narrower content row, and `renderLine` slices `line[pos:pos+region.Size]` past the end of it:

``` 
panic: runtime error: slice bounds out of range [:201] with capacity 95
```

A simple repro is a window shrink followed by a full-screen redraw (clear + repaint).
 
The fix is a one-liner: track the new width in ResizeX so later (re)inits seed the right size.

N.B. This is a sibling of 08bad7a ("fix panic when growing height + shrinking width"): that one fixed `Screen.Width`, but `Screen.Format.Width` (the `Canvas`'s own width) was left stale.
