### PR TITLE
feat: fire OnScrollback hook for lines scrolled off the main screen

### DIFF
--- a/terminal.go
+++ b/terminal.go
@@ -219,8 +219,11 @@ func (v *Terminal) ResizeY(rows int) {
 
 type OnScrollbackFunc func(line Line)
 
-// OnScrollback sets a hook that is called every time a line is about to be
-// pushed out of the visible screen region.
+// OnScrollback sets a hook called for each line pushed into scrollback, i.e.
+// scrolled off the top of the main screen. It does not fire on the alternate
+// screen (which has no scrollback) or for scrolls confined to a bounded scroll
+// region. The hook runs synchronously while input is being processed and must
+// not re-enter the terminal (e.g. Write, Resize).
 func (v *Terminal) OnScrollback(f OnScrollbackFunc) {
 	v.mut.Lock()
 	v.onScrollback = f
@@ -552,13 +555,25 @@ func (v *Terminal) scrollDownN(n int) {
 }
 
 func (v *Terminal) scrollUpN(n int) {
-	if v.onScrollback != nil {
-		for i := 0; i < n; i++ {
-			// v.onScrollback(Line{v.Content[i], v.Format[i]})
+	start, end := v.scrollRegion()
+	// only a full-screen scroll of the main screen produces scrollback
+	var evicted []Line
+	if v.onScrollback != nil && !v.IsAlt && start == 0 && end == v.Height-1 {
+		for i := 0; i < n && i < len(v.Content); i++ {
+			// snapshot before scrollUp recycles the row
+			content := append([]rune(nil), v.Content[i]...)
+			format := make([]Format, len(content))
+			col := 0
+			for r := range v.Format.Regions(i) {
+				for j := 0; j < r.Size && col < len(format); j++ {
+					format[col] = r.F
+					col++
+				}
+			}
+			evicted = append(evicted, Line{Content: content, Format: format})
 		}
 	}
 	// v.wrap = false // scroll up does NOT reset the wrap state.
-	start, end := v.scrollRegion()
 	scrollUp(v.Content, n, start, end, ' ')
 	scrollUpShallow(v.Format.Rows, n, start, end, func() *Region {
 		return &Region{Size: v.Width, F: v.Cursor.F}
@@ -566,6 +581,10 @@ func (v *Terminal) scrollUpN(n int) {
 	scrollUpShallow(v.Changes, n, start, end, func() uint64 {
 		return 1
 	})
+	// deliver from the stable post-scroll state
+	for _, line := range evicted {
+		v.onScrollback(line)
+	}
 }
 
 func (v *Terminal) scrollRegion() (int, int) {

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -291,6 +291,70 @@ func TestResizeNarrowThenRedrawDoesNotPanic(t *testing.T) {
 	require.NoError(t, vt.Render(buf))
 }
 
+// TestOnScrollback verifies the OnScrollback hook fires for each line
+// pushed off the top of the main screen - in order, with its content and
+// formatting - and stays silent on the alt screen, which has no
+// scrollback.
+func TestOnScrollback(t *testing.T) {
+	t.Run("fires for lines scrolled off the main screen", func(t *testing.T) {
+		vt := midterm.NewTerminal(3, 20)
+
+		var got []string
+		vt.OnScrollback(func(line midterm.Line) {
+			got = append(got, strings.TrimRight(string(line.Content), " "))
+		})
+
+		// Five lines into a three-row screen: the first two fall into history.
+		mustFprintf(t, vt, "line 1\r\nline 2\r\nline 3\r\nline 4\r\nline 5")
+
+		require.Equal(t, []string{"line 1", "line 2"}, got)
+	})
+
+	t.Run("preserves the evicted line's formatting", func(t *testing.T) {
+		vt := midterm.NewTerminal(2, 10)
+
+		var got []midterm.Line
+		vt.OnScrollback(func(line midterm.Line) {
+			got = append(got, line)
+		})
+
+		// Bold the first line, then push it off the two-row screen.
+		mustFprintf(t, vt, "\x1b[1mAB\x1b[0m\r\nplain\r\nx")
+
+		require.Len(t, got, 1)
+		require.Len(t, got[0].Format, len(got[0].Content))
+		require.True(t, got[0].Format[0].IsBold())
+		require.True(t, got[0].Format[1].IsBold())
+	})
+
+	t.Run("stays silent on the alt screen", func(t *testing.T) {
+		vt := midterm.NewTerminal(3, 20)
+
+		var calls int
+		vt.OnScrollback(func(midterm.Line) { calls++ })
+
+		// Enter the alt screen (DECSET 1049), then overflow it.
+		mustFprintf(t, vt, "\x1b[?1049h")
+		require.True(t, vt.IsAlt)
+		mustFprintf(t, vt, "line 1\r\nline 2\r\nline 3\r\nline 4\r\nline 5")
+
+		require.Zero(t, calls)
+	})
+
+	t.Run("stays silent for a bounded scroll region", func(t *testing.T) {
+		vt := midterm.NewTerminal(5, 20)
+
+		var calls int
+		vt.OnScrollback(func(midterm.Line) { calls++ })
+
+		// A scroll region smaller than the screen isn't history-producing.
+		vt.SetScrollingRegion(2, 4)
+		vt.ScrollUp(3)
+
+		require.Zero(t, calls)
+	})
+}
+
 func TestInsertModePreservesShiftedContentAcrossLines(t *testing.T) {
 	term := midterm.NewTerminal(24, 80)
 	term.Raw = true


### PR DESCRIPTION
OnScrollback is already public and documented ("called every time a line is about to be pushed out of the visible screen region"), but the implementation in scrollUpN is a no-op - the call was commented out, so setting the hook does nothing today.

This PR wires it up: when the main screen scrolls a line off the top, the hook fires with that line (content + per-cell format).

A few details:
  - It only fires for history-producing scrolls - the main screen (not the alt screen, which has no scrollback) with a full-screen scroll region. Partial-region scrolls don't accumulate history.
  - Each line is deep-copied before the scroll (since scrollUp recycles the row slices), and the hook fires afterward, from the stable post-scroll state.
  - The per-cell Format is rebuilt from the canvas regions, so the hook gets the same Line shape that Render produces.

I also tightened the doc to match this contract - including that the hook runs synchronously during input and shouldn't re-enter the terminal.