### PR TITLE
fix: prevent attribute bleed between rendered regions

### DIFF
--- a/render.go
+++ b/render.go
@@ -75,12 +75,13 @@ func (vt *Terminal) renderLine(w io.Writer, row int, fg, bg termenv.Color) error
 	lastFormat := EmptyFormat
 	format := func(f Format) error {
 		if lastFormat != f {
-			// TODO: this is probably a sane thing to do, but it makes picky tests
-			// fail; what if the last format set Italic? we need to reset it if the
-			// new format doesn't also set it.
-			// if lastFormat != EmptyFormat {
-			// 	fmt.Fprint(w, resetSeq)
-			// }
+			// RenderFgBg emits only "on" sequences; if f drops an attribute or
+			// color the previous format set, reset first so it doesn't bleed in.
+			if leaksInto(lastFormat, f, fg, bg) {
+				if err := write(resetSeq); err != nil {
+					return err
+				}
+			}
 			if err := write(f.RenderFgBg(fg, bg)); err != nil {
 				return err
 			}
@@ -170,6 +171,32 @@ func (vt *Terminal) renderLine(w io.Writer, row int, fg, bg termenv.Color) error
 	}
 
 	return write(resetSeq)
+}
+
+// leaksInto reports whether emitting f right after prev needs an explicit
+// reset first: RenderFgBg emits only "on" sequences, so any attribute or color
+// prev set that f drops would otherwise bleed through. fg and bg are
+// RenderFgBg's fallback colors for unset sides.
+func leaksInto(prev, f Format, fg, bg termenv.Color) bool {
+	// the empty and reset formats already render from a clean slate.
+	if f.IsReset() || f == (Format{}) {
+		return false
+	}
+	const attrs = BoldBit | FaintBit | ItalicBit | UnderlineBit | BlinkBit | ReverseBit | ConcealBit
+	if (prev.Properties&attrs)&^f.Properties != 0 {
+		return true
+	}
+	if orColor(prev.Fg, fg) != nil && orColor(f.Fg, fg) == nil {
+		return true
+	}
+	return orColor(prev.Bg, bg) != nil && orColor(f.Bg, bg) == nil
+}
+
+func orColor(c, fallback termenv.Color) termenv.Color {
+	if c != nil {
+		return c
+	}
+	return fallback
 }
 
 // searchHighlightAt checks if col falls within any search highlight range

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -355,6 +355,39 @@ func TestOnScrollback(t *testing.T) {
 	})
 }
 
+// TestRenderResetsClearedAttributes verifies renderLine resets SGR state
+// between regions only when the next region drops an attribute the previous
+// one set - so attributes don't bleed forward, without resetting needlessly.
+func TestRenderResetsClearedAttributes(t *testing.T) {
+	const reset = "\x1b[0m"
+
+	// between returns the bytes emitted between the "AB" and "CD" runs.
+	between := func(out string) string {
+		return out[strings.Index(out, "AB")+2 : strings.Index(out, "CD")]
+	}
+
+	t.Run("resets when a region drops an attribute", func(t *testing.T) {
+		vt := midterm.NewTerminal(1, 4)
+		// reverse+red "AB", then plain red "CD" (SGR 27 cancels reverse) -
+		// reverse must not bleed into CD.
+		mustFprintf(t, vt, "\x1b[7;31mAB\x1b[27mCD")
+
+		var buf bytes.Buffer
+		require.NoError(t, vt.Render(&buf))
+		require.Contains(t, between(buf.String()), reset)
+	})
+
+	t.Run("does not reset when a region only adds attributes", func(t *testing.T) {
+		vt := midterm.NewTerminal(1, 4)
+		// red "AB", then reverse+red "CD" - red carries over, no reset needed.
+		mustFprintf(t, vt, "\x1b[31mAB\x1b[7mCD")
+
+		var buf bytes.Buffer
+		require.NoError(t, vt.Render(&buf))
+		require.NotContains(t, between(buf.String()), reset)
+	})
+}
+
 func TestInsertModePreservesShiftedContentAcrossLines(t *testing.T) {
 	term := midterm.NewTerminal(24, 80)
 	term.Raw = true


### PR DESCRIPTION
Hi @vito 

I'm using midterm in a (for now) private project, and I hit a problem already reported in this TODO:

			// TODO: this is probably a sane thing to do, but it makes picky tests
			// fail; what if the last format set Italic? we need to reset it if the
			// new format doesn't also set it.
			

This PR brings the smallest changeset I could make to fix it. Below is the AI-generated description :angel: with more details.

> When renderLine walks a row region by region, it emits only the "on" SGR sequences for each region's format - RenderFgBg never emits the "off" counterparts. So if a region drops an attribute or color that the previous one set (reverse, faint, a fg/bg color), it bleeds forward into the following cells.
> 
> The format closure even carried a TODO admitting exactly this ("this is probably a sane thing to do, but it makes picky tests fail") - this PR resolves it and drops the comment.
> 
> The fix is surgical: before emitting a region's format, reset first only when the previous format has an attribute or color that the new one doesn't re-establish (a small leaksInto helper).
> Transitions that only add attributes don't reset, and the empty/reset formats are left alone since RenderFgBg already renders those from a clean slate.
> 
> N.B. RenderFgBg (and Format.Render()) stay untouched - the reset lives in the render loop, not in the per-format serialization.
> 
> Golden diff: none. TestGolden passes against the existing fixtures unchanged, since the recordings emit full SGR resets between styled runs and never hit a bare attribute drop - so the fix only kicks in exactly where a real bleed would happen.
> 
> Added TestRenderResetsClearedAttributes to pin both directions: reverse+red then plain red must reset (no bleed), while red then reverse+red must not (no needless reset).


Thanks 🙏